### PR TITLE
[Fix] bsearch teq

### DIFF
--- a/binary_search.rb
+++ b/binary_search.rb
@@ -12,12 +12,12 @@ class Array
         return num
     end
 
-    def ltep(x)         # x以下の最も近い要素，なければnil
+    def lteq(x)         # x以下の最も近い要素，なければnil
         num = (self.bsearch_index {|i| !(i<=x)} || self.size) - 1
         return num < 0 ? nil : self[num]
     end
 
-    def ltep_index(x)   # x以下の最も近い要素の場所，なければnil
+    def lteq_index(x)   # x以下の最も近い要素の場所，なければnil
         num = (self.bsearch_index {|i| !(i<=x)} || self.size) - 1
         num = nil if num < 0
         return num
@@ -31,11 +31,11 @@ class Array
         self.bsearch_index{|i| i > x}  || nil
     end
 
-    def gtep(x)         # x以上の最も近い要素，なければnil
+    def gteq(x)         # x以上の最も近い要素，なければnil
         self.bsearch{|i| i >= x} || nil
     end
 
-    def gtep_index(x)   # x以上の最も近い要素の場所，なければnil
+    def gteq_index(x)   # x以上の最も近い要素の場所，なければnil
         self.bsearch_index{|i| i >= x}  || nil
     end
 
@@ -64,7 +64,7 @@ class Array
         return [num, 0].max
     end
 
-    def count_ltep(x)   # x以下の個数
+    def count_lteq(x)   # x以下の個数
         num = self.bsearch_index{|i| i > x} || self.size
         return [num, 0].max
     end
@@ -74,12 +74,12 @@ class Array
         return self.size - num
     end
 
-    def count_gtep(x)   # x以上の個数
+    def count_gteq(x)   # x以上の個数
         num = self.bsearch_index{|i| i >= x} || self.size
         return self.size - num
     end
 
-    def count_tep(*arg) # x以上y以下(x, y)の個数, (Range)の個数
+    def count_teq(*arg) # x以上y以下(x, y)の個数, (Range)の個数
         if arg.size == 2
             num_low = self.bsearch_index{|i| i >= arg[0]} || self.size
             num_up = self.bsearch_index{|i| i > arg[1]} || self.size
@@ -113,16 +113,16 @@ p ar.lt(x)           # 要素
 p ar.lt_index(x)     # 場所
 
 # x以下の最も近いもの，なければnil
-p ar.ltep(x)         # 要素
-p ar.ltep_index(x)   # 場所
+p ar.lteq(x)         # 要素
+p ar.lteq_index(x)   # 場所
 
 # xよりの最も近いもの，なければnil
 p ar.gt(x)           # 要素
 p ar.gt_index(x)     # 場所
 
 # x以上の最も近いもの，なければnil
-p ar.gtep(x)         # 要素
-p ar.gtep_index(x)   # 場所
+p ar.gteq(x)         # 要素
+p ar.gteq_index(x)   # 場所
 
 # xに最も近いもの
 p ar.near(x)         # 要素
@@ -132,17 +132,17 @@ p ar.near_index(x)   # 場所
 p ar.count_lt(x)
 
 # x以下の個数
-p ar.count_ltep(x)
+p ar.count_lteq(x)
 
 # xより大きい要素の個数
 p ar.count_gt(x)
 
 # x以上の個数
-p ar.count_gtep(x)
+p ar.count_gteq(x)
 
 # x以上y以下の要素の個数
-p ar.count_tep(x, y)
-p ar.count_tep(x..y)
+p ar.count_teq(x, y)
+p ar.count_teq(x..y)
 
 # x以上y未満の要素の個数
-p ar.count_tep(x...y)
+p ar.count_teq(x...y)


### PR DESCRIPTION
メソッド名tepになっていたのでteqに修正