### PR TITLE
[Fix] OrderedSet count_lt commentout

### DIFF
--- a/ordered_set.rb
+++ b/ordered_set.rb
@@ -123,7 +123,7 @@ class OrderedSet
     end
     ans
   end
-  # xより小さい要素数を数える。lteqはless than or equal
+  # x以下の要素数を数える。lteqはless than or equal
   def count_lteq(x)
     ans = 0
     @a.each do |a|


### PR DESCRIPTION
count_lt(x) メソッドのコメントを修正
より小さい --> 以下の